### PR TITLE
Remove `xorg-x11-fonts-converted` from `base`/`xorg`

### DIFF
--- a/workloads/base/Dockerfile
+++ b/workloads/base/Dockerfile
@@ -11,7 +11,7 @@ RUN zypper -n refresh && \
         # fonts
         unicode-emoji liberation-fonts \
         twemoji-color-font google-noto-coloremoji-fonts \
-        xorg-x11-fonts xorg-x11-fonts-converted xorg-x11-fonts-core xorg-x11-fonts-legacy \
+        xorg-x11-fonts xorg-x11-fonts-core xorg-x11-fonts-legacy \
         adobe-sourcesans3-fonts adobe-sourcesanspro-fonts adobe-sourceserifpro-fonts \
         # Mesa drivers
         Mesa Mesa-dri Mesa-gallium Mesa-libEGL1 Mesa-libGL1 \

--- a/workloads/xorg/Dockerfile
+++ b/workloads/xorg/Dockerfile
@@ -5,7 +5,7 @@ RUN zypper --non-interactive refresh && \
 	zypper install -y \
         shadow \
 		awk \
-        xorg-x11-fonts xorg-x11-fonts-converted xorg-x11-fonts-core \
+        xorg-x11-fonts xorg-x11-fonts-core \
 		xorg-x11-server-extra dbus-1 \
 		libxcb1 \
 		libxcb-cursor0 \


### PR DESCRIPTION
This package seems to be unavailable, causing the build to [fail](https://github.com/qubesome/workload-images/actions/runs/15442866577/job/43464696709).