### PR TITLE
build: Remove execution of `make build` from pushes

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,7 +2,8 @@ name: build-images
 
 on:
   pull_request:
-  push:
+    branches:
+      - main
 
   workflow_dispatch:
 


### PR DESCRIPTION
Avoid running make build twice, by only executing it on new Pull requests.